### PR TITLE
Add Evaluation for ResponsesApi and non-conversational agent examples

### DIFF
--- a/non-conversational-agent/README.md
+++ b/non-conversational-agent/README.md
@@ -152,10 +152,10 @@ Evaluate your agent by calling the invoke function you defined for the agent loc
 - Update your `evaluate_agent.py` file with the preferred evaluation dataset and scorers. 
 - Your evaluation dataset must match the predict function signature. The wrapper takes a single argument named `data`, so each row should use `{"inputs": {"data": {...}}}` and the inner dict must match `AgentInput` (ex `document_text`, `questions: [{"text": str}]`).
 
-Run the evaluation using:
+Run the evaluation using the evaluation script:
 
 ```bash
-python src/agent_server/evaluate_agent.py
+uv run agent-evaluate
 ```
 
 After it completes, open the MLflow UI link for your experiment to inspect results.

--- a/non-conversational-agent/README.md
+++ b/non-conversational-agent/README.md
@@ -146,6 +146,20 @@ curl -X POST http://localhost:8000/invocations \
   }'
 ```
 
+### Evaluating your agent
+
+Evaluate your agent by calling the invoke function you defined for the agent locally. 
+- Update your `evaluate_agent.py` file with the preferred evaluation dataset and scorers. 
+- Your evaluation dataset must match the predict function signature. The wrapper takes a single argument named `data`, so each row should use `{"inputs": {"data": {...}}}` and the inner dict must match `AgentInput` (ex `document_text`, `questions: [{"text": str}]`).
+
+Run the evaluation using:
+
+```bash
+python src/agent_server/evaluate_agent.py
+```
+
+After it completes, open the MLflow UI link for your experiment to inspect results.
+
 ## Deploying to Databricks Apps
 
 0. **Create a Databricks App**:

--- a/non-conversational-agent/pyproject.toml
+++ b/non-conversational-agent/pyproject.toml
@@ -31,3 +31,4 @@ dev = [
 
 [project.scripts]
 agent-server = "agent_server.agent:main"
+agent-evaluate = "agent_server.evaluate_agent:evaluate"

--- a/non-conversational-agent/src/agent_server/evaluate_agent.py
+++ b/non-conversational-agent/src/agent_server/evaluate_agent.py
@@ -27,6 +27,7 @@ eval_dataset = [
     },
 ]
 
+# Get the invoke function that was registered via @invoke decorator in your agent
 invoke_fn = get_invoke_function()
 
 def predict_fn(data: dict) -> dict:

--- a/non-conversational-agent/src/agent_server/evaluate_agent.py
+++ b/non-conversational-agent/src/agent_server/evaluate_agent.py
@@ -1,0 +1,36 @@
+import mlflow
+from mlflow.genai.scorers import Safety
+from agent import invoke
+from mlflow_config import setup_mlflow
+import asyncio
+
+def predict_fn(data: dict) -> dict:
+    return asyncio.run(invoke(data))
+
+# The value of "data" must match AgentInput expected by invoke: {document_text, questions:[{text}]}
+eval_dataset = [
+    {
+        "inputs": {
+            "data": {
+                "document_text": (
+                    "Databricks supports Agents on Apps. "
+                    "Databricks was founded in 2013."
+                ),
+                "questions": [
+                    {"text": "Is Databricks mentioned in the document?"},
+                    {"text": "Does the document say who the founder of Databricks is?"},
+                ],
+            }
+        },
+    },
+]
+
+setup_mlflow()
+
+results = mlflow.genai.evaluate(
+    data=eval_dataset,
+    predict_fn=predict_fn,
+    scorers=[Safety()],
+)
+print(results)
+print("✅ MLflow evaluation completed")

--- a/non-conversational-agent/src/agent_server/evaluate_agent.py
+++ b/non-conversational-agent/src/agent_server/evaluate_agent.py
@@ -1,13 +1,15 @@
 import mlflow
 from mlflow.genai.scorers import Safety
-from agent import invoke
-from mlflow_config import setup_mlflow
+from agent_server import agent # need to import agent for our @invoke-registered function to be found
+from agent_server.server import get_invoke_function
 import asyncio
 
-def predict_fn(data: dict) -> dict:
-    return asyncio.run(invoke(data))
-
-# The value of "data" must match AgentInput expected by invoke: {document_text, questions:[{text}]}
+# Create your evaluation dataset
+# Refer to documentation for evaluations:
+# Scorers: https://docs.databricks.com/aws/en/mlflow3/genai/eval-monitor/concepts/scorers
+# Predefined LLM scorers: https://mlflow.org/docs/latest/genai/eval-monitor/scorers/llm-judge/predefined
+# Defining custom scorers: https://docs.databricks.com/aws/en/mlflow3/genai/eval-monitor/custom-scorers
+# The value of "data" must match input defined by your agent
 eval_dataset = [
     {
         "inputs": {
@@ -25,12 +27,22 @@ eval_dataset = [
     },
 ]
 
-setup_mlflow()
+invoke_fn = get_invoke_function()
 
-results = mlflow.genai.evaluate(
-    data=eval_dataset,
-    predict_fn=predict_fn,
-    scorers=[Safety()],
-)
-print(results)
-print("✅ MLflow evaluation completed")
+def predict_fn(data: dict) -> dict:
+    return asyncio.run(invoke_fn(data))
+
+
+def evaluate():
+    assert (
+        invoke_fn is not None
+    ), "No @invoke-registered function found. Ensure your predict function is decorated with @invoke()."
+
+
+    results = mlflow.genai.evaluate(
+        data=eval_dataset,
+        predict_fn=predict_fn,
+        scorers=[Safety()],
+    )
+    print(results)
+    print("✅ MLflow evaluation completed")

--- a/non-conversational-agent/src/agent_server/evaluate_agent.py
+++ b/non-conversational-agent/src/agent_server/evaluate_agent.py
@@ -39,11 +39,8 @@ def evaluate():
         invoke_fn is not None
     ), "No @invoke-registered function found. Ensure your predict function is decorated with @invoke()."
 
-
-    results = mlflow.genai.evaluate(
+    mlflow.genai.evaluate(
         data=eval_dataset,
         predict_fn=predict_fn,
         scorers=[Safety()],
     )
-    print(results)
-    print("✅ MLflow evaluation completed")

--- a/non-conversational-agent/src/agent_server/server.py
+++ b/non-conversational-agent/src/agent_server/server.py
@@ -39,6 +39,8 @@ def invoke() -> Callable:
 
     return decorator
 
+def get_invoke_function():
+    return _invoke_function
 
 def stream() -> Callable:
     """Decorator to register a function as a stream endpoint. Can only be used once."""

--- a/responses-api-agent/README.md
+++ b/responses-api-agent/README.md
@@ -159,6 +159,19 @@ Now you can either query your agent via the built in UI (served by default at ht
    -d '{ "input": [{ "role": "user", "content": "hi" }] }'
   ```
 
+### Evaluating your agent
+
+Evaluate your agent by calling the invoke function you defined for the agent locally. 
+- Update your `evaluate_agent.py` file with the preferred evaluation dataset and scorers. 
+
+Run the evaluation using:
+
+```bash
+python src/agent_server/evaluate_agent.py
+```
+
+After it completes, open the MLflow UI link for your experiment to inspect results.
+
 ## Deploying to Databricks Apps
 
 0. **Create a Databricks App**:

--- a/responses-api-agent/README.md
+++ b/responses-api-agent/README.md
@@ -164,10 +164,10 @@ Now you can either query your agent via the built in UI (served by default at ht
 Evaluate your agent by calling the invoke function you defined for the agent locally. 
 - Update your `evaluate_agent.py` file with the preferred evaluation dataset and scorers. 
 
-Run the evaluation using:
+Run the evaluation using the evaluation script:
 
 ```bash
-python src/agent_server/evaluate_agent.py
+uv run agent-evaluate
 ```
 
 After it completes, open the MLflow UI link for your experiment to inspect results.

--- a/responses-api-agent/pyproject.toml
+++ b/responses-api-agent/pyproject.toml
@@ -29,3 +29,4 @@ dev = [
 
 [project.scripts]
 agent-server = "agent_server.agent:main"
+agent-evaluate = "agent_server.evaluate_agent:evaluate"

--- a/responses-api-agent/src/agent_server/evaluate_agent.py
+++ b/responses-api-agent/src/agent_server/evaluate_agent.py
@@ -27,10 +27,8 @@ def evaluate():
         invoke_fn is not None
     ), "No @invoke-registered function found. Ensure your predict function is decorated with @invoke()."
 
-    results = mlflow.genai.evaluate(
+    mlflow.genai.evaluate(
         data=eval_dataset,
         predict_fn=invoke_fn,
         scorers=[RelevanceToQuery(), Safety()],
     )
-    print(results)
-    print("✅ MLflow evaluation completed")

--- a/responses-api-agent/src/agent_server/evaluate_agent.py
+++ b/responses-api-agent/src/agent_server/evaluate_agent.py
@@ -1,0 +1,24 @@
+import mlflow
+from mlflow.genai.scorers import RelevanceToQuery, Safety
+from agent import predict 
+
+
+eval_dataset = [
+    {
+        "inputs": {
+            "request": {
+                "input": [{"role": "user", "content": "Calculate the 15th Fibonacci number"}]
+            }
+        },
+        "expected_response": "The 15th Fibonacci number is 610.",
+    }
+]
+
+
+results = mlflow.genai.evaluate(
+    data=eval_dataset,
+    predict_fn=predict,  # pass your agent's @invoke function directly
+    scorers=[RelevanceToQuery(), Safety()],
+)
+print(results)
+print("✅ MLflow evaluation completed")

--- a/responses-api-agent/src/agent_server/evaluate_agent.py
+++ b/responses-api-agent/src/agent_server/evaluate_agent.py
@@ -1,31 +1,31 @@
-def evaluate():
-    import mlflow
-    from mlflow.genai.scorers import RelevanceToQuery, Safety
-    from agent_server import agent # need to import agent for our @invoke-registered function to be found
-    from agent_server.server import get_invoke_function
+import mlflow
+from mlflow.genai.scorers import RelevanceToQuery, Safety
+from agent_server import agent # need to import agent for our @invoke-registered function to be found
+from agent_server.server import get_invoke_function
 
-    # Resolve the invoke function that was registered via @invoke decorator in your agent
-    invoke_fn = get_invoke_function()
+# Create your evaluation dataset
+# Refer to documentation for evaluations:
+# Scorers: https://docs.databricks.com/aws/en/mlflow3/genai/eval-monitor/concepts/scorers
+# Predefined LLM scorers: https://mlflow.org/docs/latest/genai/eval-monitor/scorers/llm-judge/predefined
+# Defining custom scorers: https://docs.databricks.com/aws/en/mlflow3/genai/eval-monitor/custom-scorers
+eval_dataset = [
+    {
+        "inputs": {
+            "request": {
+                "input": [{"role": "user", "content": "Calculate the 15th Fibonacci number"}]
+            }
+        },
+        "expected_response": "The 15th Fibonacci number is 610.",
+    }
+]
+
+# Get the invoke function that was registered via @invoke decorator in your agent
+invoke_fn = get_invoke_function()
+
+def evaluate():
     assert (
         invoke_fn is not None
     ), "No @invoke-registered function found. Ensure your predict function is decorated with @invoke()."
-
-    # Create your evaluation dataset
-    # Refer to documentation for evaluations:
-    # Scorers: https://docs.databricks.com/aws/en/mlflow3/genai/eval-monitor/concepts/scorers
-    # Predefined LLM scorers: https://mlflow.org/docs/latest/genai/eval-monitor/scorers/llm-judge/predefined
-    # Defining custom scorers: https://docs.databricks.com/aws/en/mlflow3/genai/eval-monitor/custom-scorers
-    eval_dataset = [
-        {
-            "inputs": {
-                "request": {
-                    "input": [{"role": "user", "content": "Calculate the 15th Fibonacci number"}]
-                }
-            },
-            "expected_response": "The 15th Fibonacci number is 610.",
-        }
-    ]
-
 
     results = mlflow.genai.evaluate(
         data=eval_dataset,

--- a/responses-api-agent/src/agent_server/evaluate_agent.py
+++ b/responses-api-agent/src/agent_server/evaluate_agent.py
@@ -1,24 +1,36 @@
-import mlflow
-from mlflow.genai.scorers import RelevanceToQuery, Safety
-from agent import predict 
+def evaluate():
+    import mlflow
+    from mlflow.genai.scorers import RelevanceToQuery, Safety
+    from agent_server import agent # need to import agent for our @invoke-registered function to be found
+    from agent_server.server import get_invoke_function
+
+    # Resolve the invoke function that was registered via @invoke decorator in your agent
+    invoke_fn = get_invoke_function()
+    assert (
+        invoke_fn is not None
+    ), "No @invoke-registered function found. Ensure your predict function is decorated with @invoke()."
+
+    # Create your evaluation dataset
+    # Refer to documentation for evaluations:
+    # Scorers: https://docs.databricks.com/aws/en/mlflow3/genai/eval-monitor/concepts/scorers
+    # Predefined LLM scorers: https://mlflow.org/docs/latest/genai/eval-monitor/scorers/llm-judge/predefined
+    # Defining custom scorers: https://docs.databricks.com/aws/en/mlflow3/genai/eval-monitor/custom-scorers
+    eval_dataset = [
+        {
+            "inputs": {
+                "request": {
+                    "input": [{"role": "user", "content": "Calculate the 15th Fibonacci number"}]
+                }
+            },
+            "expected_response": "The 15th Fibonacci number is 610.",
+        }
+    ]
 
 
-eval_dataset = [
-    {
-        "inputs": {
-            "request": {
-                "input": [{"role": "user", "content": "Calculate the 15th Fibonacci number"}]
-            }
-        },
-        "expected_response": "The 15th Fibonacci number is 610.",
-    }
-]
-
-
-results = mlflow.genai.evaluate(
-    data=eval_dataset,
-    predict_fn=predict,  # pass your agent's @invoke function directly
-    scorers=[RelevanceToQuery(), Safety()],
-)
-print(results)
-print("✅ MLflow evaluation completed")
+    results = mlflow.genai.evaluate(
+        data=eval_dataset,
+        predict_fn=invoke_fn,
+        scorers=[RelevanceToQuery(), Safety()],
+    )
+    print(results)
+    print("✅ MLflow evaluation completed")

--- a/responses-api-agent/src/agent_server/server.py
+++ b/responses-api-agent/src/agent_server/server.py
@@ -40,6 +40,9 @@ def invoke() -> Callable:
 
     return decorator
 
+def get_invoke_function():
+    return _invoke_function
+
 
 def stream() -> Callable:
     """Decorator to register a function as a stream endpoint. Can only be used once."""


### PR DESCRIPTION
### CHANGE
Add snippets for using `mlflow.gen.evaluate` with the locally defined agent predict function that has @invoke decorator for both the responses-api-agent and non-conversational-agent examples

- Adds accessor method for our invoke function in the agent server to retrieve the function the user defined with the @invoke decorator
- Adds agent evaluation code in `evaluate_agent.py` for both non-conversational and responses-api agent examples, with examples on proper input format for the eval dataset
- Update `pyproject.toml` with new agent evaluation script
- Update README instructions for both agents for running the evaluation script

### TESTING
Run `uv run agent-evaluate` in the respective agent's folder and receive MLFlow trace links via output like so:
```
2025/09/23 18:07:52 INFO mlflow.genai.utils.data_validation: Testing model prediction with the first sample in the dataset.
Evaluating: 100%|███████████████████████████████████████████████████████████████████████| 1/1 [Elapsed: 00:07, Remaining: 00:00] , Time breakdown=(74.54% predict_fn, 25.46% scorers)
Evaluation completed.

Metrics and evaluation results can be viewed from the MLflow run page.
To compare evaluation results across runs, view the "Evaluations" tab of the experiment.

Get aggregate metrics: `result.metrics`.
Get per-row evaluation results: `result.tables['eval_results']`.
`result` is the `EvaluationResult` object returned by `mlflow.evaluate`.

🏃 View run invincible-bird-407 at: https://e2-dogfood.staging.cloud.databricks.com/ml/experiments/2105341160120047/runs/2ac51ddca506429c8f35d632ec21e943
🧪 View experiment at: https://e2-dogfood.staging.cloud.databricks.com/ml/experiments/2105341160120047
```