### PR TITLE
disable openai tracing errors

### DIFF
--- a/openai-agents-sdk/src/agent_server/agent.py
+++ b/openai-agents-sdk/src/agent_server/agent.py
@@ -19,7 +19,7 @@ sp_workspace_client = WorkspaceClient()
 databricks_openai_client = get_async_openai_client(sp_workspace_client)
 set_default_openai_client(databricks_openai_client)
 set_default_openai_api("chat_completions")
-set_trace_processors([])
+set_trace_processors([])  # use mlflow for trace processing
 mlflow.openai.autolog()
 
 

--- a/openai-agents-sdk/src/agent_server/agent.py
+++ b/openai-agents-sdk/src/agent_server/agent.py
@@ -3,6 +3,7 @@ from typing import AsyncGenerator
 import mlflow
 from agents import Agent, Runner, set_default_openai_api, set_default_openai_client
 from agents.mcp import MCPServerStdio, MCPServerStreamableHttp, MCPServerStreamableHttpParams
+from agents.tracing import set_trace_processors
 from databricks.sdk import WorkspaceClient
 from mlflow.types.responses import (
     ResponsesAgentRequest,
@@ -14,10 +15,11 @@ from agent_server.server import get_obo_workspace_client, invoke, stream
 from agent_server.utils import get_async_openai_client, get_databricks_host_from_env
 
 sp_workspace_client = WorkspaceClient()
-# NOTE: this will work for all databricks models *other* than GPT-OSS, which uses a slightly different API
+# NOTE: this will work for all databricks models OTHER than GPT-OSS, which uses a slightly different API
 databricks_openai_client = get_async_openai_client(sp_workspace_client)
 set_default_openai_client(databricks_openai_client)
 set_default_openai_api("chat_completions")
+set_trace_processors([])
 mlflow.openai.autolog()
 
 


### PR DESCRIPTION
because we use "no-token", openai tracing throws a nonfatal warning. 

```
[non-fatal] Tracing client error 401: {
  "error": {
    "message": "Incorrect API key provided: no-token. You can find your API key at https://platform.openai.com/account/api-keys.",
    "type": "invalid_request_error",
    "param": null,
    "code": "invalid_api_key"
  }
}
```
source: https://github.com/openai/openai-agents-python/blob/4ba2e8af4f85f4c628fef72fcb01e05cf705185b/src/agents/tracing/processors.py#L130

fix: https://github.com/openai/openai-agents-python/issues/1387#issuecomment-3165660183